### PR TITLE
feat(leader): implement full create leader flow

### DIFF
--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -11,11 +11,14 @@ import (
 	resendClient "github.com/amorindev/go-tmpl/internal/resend"
 	tokenService "github.com/amorindev/go-tmpl/internal/tokens/service"
 	adminHandler "github.com/amorindev/go-tmpl/pkg/features/admin/api/handler"
+	leaderHandler "github.com/amorindev/go-tmpl/pkg/features/app/leader/handler"
+	leaderRepository "github.com/amorindev/go-tmpl/pkg/features/app/leader/repository/mongo"
+	leaderService "github.com/amorindev/go-tmpl/pkg/features/app/leader/service"
 	authHandler "github.com/amorindev/go-tmpl/pkg/features/auth/handler"
 	authService "github.com/amorindev/go-tmpl/pkg/features/auth/service"
 	resendAdapter "github.com/amorindev/go-tmpl/pkg/features/mailer/adapter/resend"
-	"github.com/amorindev/go-tmpl/pkg/features/mailer/service"
-	"github.com/amorindev/go-tmpl/pkg/features/opt-codes/repository/mongo"
+	mailerService "github.com/amorindev/go-tmpl/pkg/features/mailer/service"
+	otpCodeRepository "github.com/amorindev/go-tmpl/pkg/features/opt-codes/repository/mongo"
 	otpCodeService "github.com/amorindev/go-tmpl/pkg/features/opt-codes/service"
 
 	sessionRepository "github.com/amorindev/go-tmpl/pkg/features/session/repository/mongo"
@@ -68,10 +71,16 @@ func New() http.Handler {
 	sessionColl := mongoDB.Collection("sessions")
 	otpCodeColl := mongoDB.Collection("opt-codes")
 
+	// Collections - app
+	leaderColl := mongoDB.Collection("leaders")
+
 	// Repositories
 	userRepo := userRepository.NewUserRepo(mongoConn.DB, userColl)
 	sessionRepo := sessionRepository.NewSessionRepo(mongoConn.DB, sessionColl)
-	otpCodeRepo := mongo.NewOtpCodeRepo(mongoConn.DB, otpCodeColl)
+	otpCodeRepo := otpCodeRepository.NewOtpCodeRepo(mongoConn.DB, otpCodeColl)
+
+	// Repositories - app
+	leaderRepo := leaderRepository.NewLeaderRepo(mongoConn.DB, leaderColl)
 
 	// Indexes
 	err = userRepo.CreateIndexes()
@@ -89,14 +98,20 @@ func New() http.Handler {
 	tokenSrv := tokenService.NewTokenSrv(appEnvs.JWTAccessSecret, appEnvs.JWTRefreshSecret, appEnvs.JWTAccessExpIn, appEnvs.JWTRefreshExpIn, appEnvs.JWTRefreshRememberMeExpIn, appEnvs.JWTIssuer)
 	sessionSrv := sessionService.NewSessionSrv(sessionRepo, tokenSrv)
 	otpCodeSrv := otpCodeService.NewOtpCodeSrv(otpCodeRepo)
-	mailerSrv := service.NewMailerSrv(mailerAdt, appEnvs.AppName)
+	mailerSrv := mailerService.NewMailerSrv(mailerAdt, appEnvs.AppName)
 	authSrv := authService.NewAuthSrv(userRepo, userFileStg, sessionSrv, otpCodeSrv, mailerSrv)
 	userSrv := userService.NewUserSrv(userRepo, userFileStg)
 
+	// Services - app
+	leaderSrv := leaderService.NewLeaderSrv(leaderRepo)
+
 	// Handler
 	// Note: all subsequent handlers should also be registered using v1
-	authHandler.NewAuthHandler(v1, authSrv, tokenSrv,appEnvs.AppEnv)
+	authHandler.NewAuthHandler(v1, authSrv, tokenSrv, appEnvs.AppEnv)
 	userHandler.NewUserHandler(v1, userSrv)
+
+	// Handler - app
+	leaderHandler.NewLeaderHandler(v1, leaderSrv)
 
 	mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/features/app/leader/core/core.go
+++ b/pkg/features/app/leader/core/core.go
@@ -1,0 +1,114 @@
+package core
+
+import (
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+// CreateLeaderReq represents the request structure for Leader creation
+type CreateLeaderReq struct {
+	FullName  string  `json:"full_name"`
+	Phrase    *string `json:"phrase"`
+	Nickname  *string `json:"nickname"`
+	ImgUrl    *string `json:"img_url"`
+	Biography string  `json:"biography"`
+
+	BirthDate   *time.Time `json:"birth_date"`
+	Nationality string     `json:"nationality"`
+	Gender      string     `json:"gender"`
+	Ideology    *string    `json:"ideology"`
+
+	Facebook  string  `json:"facebook"`
+	Instagram string  `json:"instagram"`
+	Twitter   *string `json:"twitter"`
+	YouTube   *string `json:"youtube"`
+	Linkedin  *string `json:"linkedin"`
+	Website   *string `json:"website"`
+}
+
+func (req *CreateLeaderReq) IsCreateLeaderValid() error {
+	// Validate email field is not empty
+	if strings.TrimSpace(req.FullName) == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "full_name is required")
+	}
+
+	if strings.TrimSpace(req.Biography) == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "biography is required")
+	}
+
+	if req.Phrase != nil && strings.TrimSpace(*req.Phrase) == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "phrase is empty")
+	}
+
+	if req.Ideology != nil && strings.TrimSpace(*req.Ideology) == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "phrase is empty")
+	}
+
+	validGenders := map[string]bool{
+		"male": true, "female": true, "other": true,
+	}
+	if !validGenders[strings.ToLower(req.Gender)] {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "gender must be male, female or other")
+	}
+
+	if strings.TrimSpace(req.Nationality) == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "nationality is required")
+	}
+
+	if req.BirthDate != nil {
+		// Prevent future birth dates
+		if req.BirthDate.After(time.Now()) {
+			return sharedD.NewAppError(domain.ErrCodeInvalidParams, "birth_date cannot be in the future")
+		}
+	}
+
+	if err := validateSocialURL(req.Facebook, "facebook"); err != nil {
+		return err
+	}
+	if err := validateSocialURL(req.Instagram, "instagram"); err != nil {
+		return err
+	}
+	if err := validateOptionalURL(req.Twitter, "twitter"); err != nil {
+		return err
+	}
+	if err := validateOptionalURL(req.YouTube, "youtube"); err != nil {
+		return err
+	}
+	if err := validateOptionalURL(req.Linkedin, "linkedin"); err != nil {
+		return err
+	}
+	if err := validateOptionalURL(req.Website, "website"); err != nil {
+		return err
+	}
+	if err := validateOptionalURL(req.ImgUrl, "img_url"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateSocialURL(urlStr, field string) error {
+	if strings.TrimSpace(urlStr) == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, field+" is required")
+	}
+	return validateURL(urlStr, field)
+}
+
+func validateOptionalURL(urlStr *string, field string) error {
+	if urlStr == nil || strings.TrimSpace(*urlStr) == "" {
+		return nil
+	}
+	return validateURL(*urlStr, field)
+}
+
+func validateURL(u, field string) error {
+	parsed, err := url.ParseRequestURI(u)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, field+" must be a valid URL")
+	}
+	return nil
+}

--- a/pkg/features/app/leader/domain/domain.go
+++ b/pkg/features/app/leader/domain/domain.go
@@ -1,0 +1,31 @@
+package domain
+
+import "time"
+
+// Leader represents a political or public figure within the system.
+// It contains personal information, biography, social media links, and metadata.
+// ImgUrl is used only for responses to the client (not stored in the database).
+// ImgPath is stored in the database and used by the backend to build the final public URL.
+type Leader struct {
+	ID        interface{} `json:"id" bson:"_id"`
+	FullName  string      `json:"full_name" bson:"full_name"`
+	NickName  *string     `json:"nickname" bson:"nickname"`
+	Phrase    *string     `json:"phrase" bson:"phrase"`
+	Biography string      `json:"biography" bson:"biography"`
+	ImgUrl    *string     `json:"img_url" bson:"-"`
+	ImgPath   *string     `json:"-" bson:"img_path"`
+
+	BirthDate   *time.Time `json:"birth_date" bson:"birth_date"`
+	Nationality string     `json:"nationality" bson:"nationality"`
+	Gender      string     `json:"gender,omitempty" bson:"gender"`
+	Ideology    *string    `json:"ideology,omitempty" bson:"ideology"`
+
+	Facebook  string  `json:"facebook" bson:"facebook"`
+	Instagram string  `json:"instagram" bson:"instagram"`
+	Twitter   *string `json:"twitter" bson:"twitter"`
+	YouTube   *string `json:"youtube" bson:"youtube"`
+	Linkedin  *string `json:"linkedin" bson:"linkedin"`
+	Website   *string `json:"website" bson:"website"`
+
+	CreatedAt *time.Time `json:"created_at" bson:"created_at"`
+}

--- a/pkg/features/app/leader/handler/create.go
+++ b/pkg/features/app/leader/handler/create.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/core"
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
+	sharedC "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var req core.CreateLeaderReq
+
+	// Decode JSON request body into SignUpReq struct
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "invalid request body"))
+		return
+	}
+
+	defer r.Body.Close()
+
+	// Validate the sign-up request
+	err = req.IsCreateLeaderValid()
+	if err != nil {
+		sharedC.RespondError(w, err)
+		return
+	}
+
+	leader := &domain.Leader{
+		FullName:    req.FullName,
+		NickName:    req.Nickname,
+		Phrase:      req.Phrase,
+		Biography:   req.Biography,
+		BirthDate:   req.BirthDate,
+		Nationality: req.Nationality,
+		Gender:      req.Gender,
+		Ideology:    req.Ideology,
+		Facebook:    req.Facebook,
+		Instagram:   req.Instagram,
+		Twitter:     req.Twitter,
+		YouTube:     req.YouTube,
+		Linkedin:    req.Linkedin,
+		Website:     req.Website,
+	}
+
+	err = h.LeaderSrv.Create(context.Background(), leader)
+	if err != nil {
+		sharedC.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(leader)
+}

--- a/pkg/features/app/leader/handler/handler.go
+++ b/pkg/features/app/leader/handler/handler.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/port"
+)
+
+type Handler struct {
+	LeaderSrv port.LeaderSrv
+}
+
+func NewLeaderHandler(server *http.ServeMux, leaderSrv port.LeaderSrv) *Handler {
+	h := &Handler{
+		LeaderSrv: leaderSrv,
+	}
+
+	server.HandleFunc("POST /leaders", h.Create)
+	
+	return h
+}

--- a/pkg/features/app/leader/port/ports.go
+++ b/pkg/features/app/leader/port/ports.go
@@ -1,0 +1,15 @@
+package port
+
+import (
+	"context"
+
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
+)
+
+type LeaderRepo interface {
+	Insert(ctx context.Context, leader *domain.Leader) error
+}
+
+type LeaderSrv interface {
+	Create(ctx context.Context, leader *domain.Leader) error
+}

--- a/pkg/features/app/leader/repository/mongo/insert.go
+++ b/pkg/features/app/leader/repository/mongo/insert.go
@@ -1,0 +1,27 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) Insert(ctx context.Context, leader *domain.Leader) error {
+	id := bson.NewObjectID()
+	leader.ID = id
+
+	_, err := r.Collection.InsertOne(ctx, leader)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("%w: error inserting leader: %s", sharedD.ErrDuplicateKey, err.Error())
+		}
+		return fmt.Errorf("error inserting leader: %s", err.Error())
+	}
+	leader.ID = id.Hex()
+
+	return nil
+}

--- a/pkg/features/app/leader/repository/mongo/repository.go
+++ b/pkg/features/app/leader/repository/mongo/repository.go
@@ -1,0 +1,22 @@
+package mongo
+
+import (
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/port"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// Make sure Repository implements ports.PlayerRepository
+// at compile time
+var _ port.LeaderRepo = &Repository{}
+
+type Repository struct {
+	Client     *mongo.Client
+	Collection *mongo.Collection
+}
+
+func NewLeaderRepo(client *mongo.Client, collection *mongo.Collection) *Repository {
+	return &Repository{
+		Client:     client,
+		Collection: collection,
+	}
+}

--- a/pkg/features/app/leader/service/create.go
+++ b/pkg/features/app/leader/service/create.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
+)
+
+func (s *Service) Create(ctx context.Context, leader *domain.Leader) error {
+	now := time.Now().UTC()
+	leader.CreatedAt = &now
+
+	err := s.LeaderRepo.Insert(ctx, leader)
+	if err != nil {
+	  return sharedD.ManageError(err, "error creating leader")
+	}
+
+	return nil
+}

--- a/pkg/features/app/leader/service/service.go
+++ b/pkg/features/app/leader/service/service.go
@@ -1,0 +1,15 @@
+package service
+
+import "github.com/amorindev/go-tmpl/pkg/features/app/leader/port"
+
+var _ port.LeaderSrv = &Service{}
+
+type Service struct {
+	LeaderRepo port.LeaderRepo
+}
+
+func NewLeaderSrv(leaderRepo port.LeaderRepo) *Service {
+	return &Service{
+		LeaderRepo: leaderRepo,
+	}
+}


### PR DESCRIPTION
### Tasks
- Add validation for create leader request
- Map request data to domain model
- Add service logic with metadata (created_at)
- Implement repository insert with ObjectID
- Expose POST /leaders endpoint
- Return created leader in response

<img width="935" height="510" alt="image" src="https://github.com/user-attachments/assets/6cba2a4e-2ca1-450d-acf3-0b11586716fb" />

<img width="944" height="612" alt="image" src="https://github.com/user-attachments/assets/2c6c3414-2b44-454f-91fb-44a9cd8a99fb" />

Close #1 