### PR TITLE
Feat #3 (app-leader): add image upload flow for avatar and banner

### DIFF
--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -11,6 +11,7 @@ import (
 	resendClient "github.com/amorindev/go-tmpl/internal/resend"
 	tokenService "github.com/amorindev/go-tmpl/internal/tokens/service"
 	adminHandler "github.com/amorindev/go-tmpl/pkg/features/admin/api/handler"
+	leaderFileStorage "github.com/amorindev/go-tmpl/pkg/features/app/leader/file-storage/minio"
 	leaderHandler "github.com/amorindev/go-tmpl/pkg/features/app/leader/handler"
 	leaderRepository "github.com/amorindev/go-tmpl/pkg/features/app/leader/repository/mongo"
 	leaderService "github.com/amorindev/go-tmpl/pkg/features/app/leader/service"
@@ -93,6 +94,7 @@ func New() http.Handler {
 
 	// File Storage
 	userFileStg := userFileStorage.NewUserFileStg(minioC.Client, appEnvs.MinioBucketName, 0)
+	leaderFileStg := leaderFileStorage.NewLeaderFileStg(minioC.Client, appEnvs.MinioBucketName, appEnvs.MinioEndpoint)
 
 	// Services
 	tokenSrv := tokenService.NewTokenSrv(appEnvs.JWTAccessSecret, appEnvs.JWTRefreshSecret, appEnvs.JWTAccessExpIn, appEnvs.JWTRefreshExpIn, appEnvs.JWTRefreshRememberMeExpIn, appEnvs.JWTIssuer)
@@ -103,7 +105,7 @@ func New() http.Handler {
 	userSrv := userService.NewUserSrv(userRepo, userFileStg)
 
 	// Services - app
-	leaderSrv := leaderService.NewLeaderSrv(leaderRepo)
+	leaderSrv := leaderService.NewLeaderSrv(leaderRepo, leaderFileStg)
 
 	// Handler
 	// Note: all subsequent handlers should also be registered using v1

--- a/pkg/features/app/leader/core/core.go
+++ b/pkg/features/app/leader/core/core.go
@@ -14,7 +14,6 @@ type CreateLeaderReq struct {
 	FullName  string  `json:"full_name"`
 	Phrase    *string `json:"phrase"`
 	Nickname  *string `json:"nickname"`
-	ImgUrl    *string `json:"img_url"`
 	Biography string  `json:"biography"`
 
 	BirthDate   *time.Time `json:"birth_date"`
@@ -82,9 +81,6 @@ func (req *CreateLeaderReq) IsCreateLeaderValid() error {
 		return err
 	}
 	if err := validateOptionalURL(req.Website, "website"); err != nil {
-		return err
-	}
-	if err := validateOptionalURL(req.ImgUrl, "img_url"); err != nil {
 		return err
 	}
 

--- a/pkg/features/app/leader/domain/domain.go
+++ b/pkg/features/app/leader/domain/domain.go
@@ -7,13 +7,15 @@ import "time"
 // ImgUrl is used only for responses to the client (not stored in the database).
 // ImgPath is stored in the database and used by the backend to build the final public URL.
 type Leader struct {
-	ID        interface{} `json:"id" bson:"_id"`
-	FullName  string      `json:"full_name" bson:"full_name"`
-	NickName  *string     `json:"nickname" bson:"nickname"`
-	Phrase    *string     `json:"phrase" bson:"phrase"`
-	Biography string      `json:"biography" bson:"biography"`
-	ImgUrl    *string     `json:"img_url" bson:"-"`
-	ImgPath   *string     `json:"-" bson:"img_path"`
+	ID         interface{} `json:"id" bson:"_id"`
+	FullName   string      `json:"full_name" bson:"full_name"`
+	NickName   *string     `json:"nickname" bson:"nickname"`
+	Phrase     *string     `json:"phrase" bson:"phrase"`
+	Biography  string      `json:"biography" bson:"biography"`
+	AvatarUrl  *string     `json:"avatar_url" bson:"-"`
+	BannerUrl  *string     `json:"banner_url" bson:"-"`
+	AvatarPath *string     `json:"-" bson:"avatar_path"`
+	BannerPath *string     `json:"-" bson:"banner_path"`
 
 	BirthDate   *time.Time `json:"birth_date" bson:"birth_date"`
 	Nationality string     `json:"nationality" bson:"nationality"`

--- a/pkg/features/app/leader/domain/types.go
+++ b/pkg/features/app/leader/domain/types.go
@@ -1,0 +1,6 @@
+package domain
+
+const (
+	LeaderImageAvatar = "avatar"
+	LeaderImageBanner = "banner"
+)

--- a/pkg/features/app/leader/file-storage/minio/file_storage.go
+++ b/pkg/features/app/leader/file-storage/minio/file_storage.go
@@ -1,0 +1,22 @@
+package minio
+
+import (
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/port"
+	"github.com/minio/minio-go/v7"
+)
+
+var _ port.LeaderFileStg = &FileStorage{}
+
+type FileStorage struct {
+	MinioClient *minio.Client
+	BucketName  string
+	BaseUrl     string
+}
+
+func NewLeaderFileStg(client *minio.Client, bucketName string, baseUrl string) *FileStorage {
+	return &FileStorage{
+		MinioClient: client,
+		BucketName:  bucketName,
+		BaseUrl:     baseUrl,
+	}
+}

--- a/pkg/features/app/leader/file-storage/minio/upload_image.go
+++ b/pkg/features/app/leader/file-storage/minio/upload_image.go
@@ -1,0 +1,22 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/minio/minio-go/v7"
+)
+
+func (fs *FileStorage) UploadImage(ctx context.Context, imgPath string, file io.Reader, contentType string) error {
+	options := minio.PutObjectOptions{
+		ContentType: contentType,
+	}
+
+	_, err := fs.MinioClient.PutObject(ctx, fs.BucketName, imgPath, file, -1, options)
+	if err != nil {
+		return fmt.Errorf("failed to upload leader image %q to bucket %q: %w", imgPath, fs.BucketName, err)
+	}
+
+	return nil
+}

--- a/pkg/features/app/leader/handler/handler.go
+++ b/pkg/features/app/leader/handler/handler.go
@@ -16,6 +16,7 @@ func NewLeaderHandler(server *http.ServeMux, leaderSrv port.LeaderSrv) *Handler 
 	}
 
 	server.HandleFunc("POST /leaders", h.Create)
+	server.HandleFunc("POST /leaders/{leaderId}/image/{type}", h.UploadAvatar)
 	
 	return h
 }

--- a/pkg/features/app/leader/handler/upload_avatar.go
+++ b/pkg/features/app/leader/handler/upload_avatar.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	sharedC "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+// UploadAvatar handles uploading an avatar or banner image for a leader.
+// It validates parameters, checks the file type, and delegates the upload to the service layer.
+func (h Handler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
+	leaderID := r.PathValue("leaderId")
+	imgType := r.PathValue("type") // avatar || banner
+
+	if leaderID == "" || imgType == "" {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "missing parameters"))
+		return
+	}
+
+	allowedTypes := map[string]bool{
+		"avatar": true,
+		"banner": true,
+	}
+
+	if !allowedTypes[imgType] {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "invalid image type"))
+		return
+	}
+
+	err := r.ParseMultipartForm(20 << 20) // 20MB
+	if err != nil {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "invalid form"))
+		return
+	}
+
+	file, header, err := r.FormFile("image")
+	if err != nil {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "error retrieving file"))
+		return
+	}
+
+	defer file.Close()
+
+	// Proper Content-Type detection
+	fileBuffer := make([]byte, 512)
+	_, err = file.Read(fileBuffer)
+	if err != nil {
+		msg := "failed to read uploaded file for content-type detection"
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInternalServerError, msg))
+		return
+	}
+	fileType := http.DetectContentType(fileBuffer)
+
+	// Reset file reader position
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		msg := "failed to reset file pointer after reading"
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInternalServerError, msg))
+		return
+	}
+
+	allowedMime := map[string]bool{
+		"image/jpeg":    true,
+		"image/png":     true,
+		"image/gif":     true,
+		"image/webp":    true,
+		"image/avif":    true,
+		"image/svg+xml": true,
+	}
+
+	if !allowedMime[fileType] {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInternalServerError, "invalid image format"))
+		return
+	}
+
+	err = h.LeaderSrv.UploadLeaderImage(context.Background(), leaderID, imgType, header.Filename, file, fileType)
+	if err != nil {
+		sharedC.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/features/app/leader/port/ports.go
+++ b/pkg/features/app/leader/port/ports.go
@@ -2,14 +2,23 @@ package port
 
 import (
 	"context"
+	"io"
 
 	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
 )
 
 type LeaderRepo interface {
 	Insert(ctx context.Context, leader *domain.Leader) error
+	Exists(ctx context.Context, id string) (bool, error)
+	UpdateAvatarPath(ctx context.Context, leaderID, imgPath string) error
+	UpdateBannerPath(ctx context.Context, leaderID, imgPath string) error
 }
 
 type LeaderSrv interface {
 	Create(ctx context.Context, leader *domain.Leader) error
+	UploadLeaderImage(ctx context.Context, leaderID, imgType, imgName string, file io.Reader, contentType string) error
+}
+
+type LeaderFileStg interface {
+	UploadImage(ctx context.Context, imgPath string, file io.Reader, contentType string) error
 }

--- a/pkg/features/app/leader/repository/mongo/exists.go
+++ b/pkg/features/app/leader/repository/mongo/exists.go
@@ -1,0 +1,26 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// Exists checks if a leader with the given id already exists in the collection.
+func (r *Repository) Exists(ctx context.Context, id string) (bool, error) {
+	oID, err := bson.ObjectIDFromHex(id)
+	if err != nil {
+		return false, fmt.Errorf("%w: failed to convert leaderID to ObjectID :%w", domain.ErrIncorrectID, err)
+	}
+
+	filter := bson.M{"_id": oID}
+
+	count, err := r.Collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return false, fmt.Errorf("error checking leader existence: %s", err.Error())
+	}
+
+	return count > 0, nil
+}

--- a/pkg/features/app/leader/repository/mongo/update_avatar_path.go
+++ b/pkg/features/app/leader/repository/mongo/update_avatar_path.go
@@ -1,0 +1,30 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) UpdateAvatarPath(ctx context.Context, leaderID, imgPath string) error {
+	oID, err := bson.ObjectIDFromHex(leaderID)
+	if err != nil {
+		return fmt.Errorf("%w: failed to convert leaderID to ObjectID :%w", domain.ErrIncorrectID, err)
+	}
+
+	filter := bson.M{"_id": oID}
+	update := bson.M{"$set": bson.M{"avatar_path": imgPath}}
+
+	result, err := r.Collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to update leader avatar path in database: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/features/app/leader/repository/mongo/update_banner_path.go
+++ b/pkg/features/app/leader/repository/mongo/update_banner_path.go
@@ -1,0 +1,30 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) UpdateBannerPath(ctx context.Context, leaderID, imgPath string) error {
+	oID, err := bson.ObjectIDFromHex(leaderID)
+	if err != nil {
+		return fmt.Errorf("%w: failed to convert leaderID to ObjectID :%w", domain.ErrIncorrectID, err)
+	}
+
+	filter := bson.M{"_id": oID}
+	update := bson.M{"$set": bson.M{"banner_path": imgPath}}
+
+	result, err := r.Collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to update leader banner path in database: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/features/app/leader/service/service.go
+++ b/pkg/features/app/leader/service/service.go
@@ -5,11 +5,13 @@ import "github.com/amorindev/go-tmpl/pkg/features/app/leader/port"
 var _ port.LeaderSrv = &Service{}
 
 type Service struct {
-	LeaderRepo port.LeaderRepo
+	LeaderRepo    port.LeaderRepo
+	LeaderFileStg port.LeaderFileStg
 }
 
-func NewLeaderSrv(leaderRepo port.LeaderRepo) *Service {
+func NewLeaderSrv(leaderRepo port.LeaderRepo, leaderFileStg port.LeaderFileStg) *Service {
 	return &Service{
 		LeaderRepo: leaderRepo,
+		LeaderFileStg: leaderFileStg,
 	}
 }

--- a/pkg/features/app/leader/service/upload_avatar.go
+++ b/pkg/features/app/leader/service/upload_avatar.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) UploadLeaderImage(ctx context.Context, leaderID, imgType, imgName string, file io.Reader, contentType string) error {
+	exists, err := s.LeaderRepo.Exists(ctx, leaderID)
+	if err != nil {
+		return sharedD.ManageError(err, "")
+	}
+
+	if !exists {
+		return sharedD.ManageError(sharedD.ErrNotFound, "")
+	}
+
+	ext := filepath.Ext(imgName)
+	path := fmt.Sprintf("leaders/%s/%s%s", imgType, leaderID, ext)
+
+	err = s.LeaderFileStg.UploadImage(ctx, path, file, contentType)
+	if err != nil {
+		return sharedD.ManageError(err, "")
+	}
+
+	// update in the database
+	switch imgType {
+	case domain.LeaderImageAvatar:
+		err = s.LeaderRepo.UpdateAvatarPath(ctx, leaderID, path)
+	case domain.LeaderImageBanner:
+		err = s.LeaderRepo.UpdateBannerPath(ctx, leaderID, path)
+	}
+
+	if err != nil {
+		return sharedD.ManageError(err, "")
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Tasks
- New endpoint to upload avatar or banner
- Image type validation and MIME detection
- Upload to storage provider
- Update leader record with avatar_path or banner_path
- Service and repository updates to support image handling

<img width="1015" height="505" alt="image" src="https://github.com/user-attachments/assets/66512fbc-fde4-4329-a8e9-a63e84bd2fb4" />

<img width="998" height="345" alt="image" src="https://github.com/user-attachments/assets/df8db934-df0f-4552-ad04-44f1bc2f0144" />

Close #3 