### PR TITLE
Feat #8 (app-leader): add random leader endpoint

### DIFF
--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -99,7 +99,7 @@ func New() http.Handler {
 
 	// File Storage
 	userFileStg := userFileStorage.NewUserFileStg(minioC.Client, appEnvs.MinioBucketName, 0)
-	leaderFileStg := leaderFileStorage.NewLeaderFileStg(minioC.Client, appEnvs.MinioBucketName, appEnvs.MinioEndpoint)
+	leaderFileStg := leaderFileStorage.NewLeaderFileStg(minioC.Client, appEnvs.MinioBucketName, 0)
 
 	// Services
 	tokenSrv := tokenService.NewTokenSrv(appEnvs.JWTAccessSecret, appEnvs.JWTRefreshSecret, appEnvs.JWTAccessExpIn, appEnvs.JWTRefreshExpIn, appEnvs.JWTRefreshRememberMeExpIn, appEnvs.JWTIssuer)

--- a/pkg/features/app/leader/file-storage/minio/file_storage.go
+++ b/pkg/features/app/leader/file-storage/minio/file_storage.go
@@ -1,6 +1,8 @@
 package minio
 
 import (
+	"time"
+
 	"github.com/amorindev/go-tmpl/pkg/features/app/leader/port"
 	"github.com/minio/minio-go/v7"
 )
@@ -10,13 +12,16 @@ var _ port.LeaderFileStg = &FileStorage{}
 type FileStorage struct {
 	MinioClient *minio.Client
 	BucketName  string
-	BaseUrl     string
+	ExpTime     time.Duration
 }
 
-func NewLeaderFileStg(client *minio.Client, bucketName string, baseUrl string) *FileStorage {
+func NewLeaderFileStg(client *minio.Client, bucketName string, expTime time.Duration) *FileStorage {
+	if expTime == 0 {
+		expTime = time.Hour * 24 * 7
+	}
 	return &FileStorage{
 		MinioClient: client,
 		BucketName:  bucketName,
-		BaseUrl:     baseUrl,
+		ExpTime:     expTime,
 	}
 }

--- a/pkg/features/app/leader/file-storage/minio/get_image.go
+++ b/pkg/features/app/leader/file-storage/minio/get_image.go
@@ -1,0 +1,20 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+func (fs *FileStorage) GetImage(ctx context.Context, imgPath string) (string, error) {
+	// Set request parameters for content-disposition.
+	reqParams := make(url.Values)
+
+	// Generates a presigned url which expires in a day.
+	presignedURL, err := fs.MinioClient.PresignedGetObject(ctx, fs.BucketName, imgPath, fs.ExpTime, reqParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned URL for leader image %q in bucket %q: %w", imgPath, fs.BucketName, err)
+	}
+
+	return presignedURL.String(), nil
+}

--- a/pkg/features/app/leader/handler/get_random.go
+++ b/pkg/features/app/leader/handler/get_random.go
@@ -1,0 +1,24 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	sharedC "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+)
+
+// GetRandom handles the HTTP request to retrieve a random leader.
+// It calls the leader service to select a leader at random
+// and returns it as a JSON response with status 200 OK.
+// If an error occurs, it responds with the corresponding error.
+func (h Handler) GetRandom(w http.ResponseWriter, r *http.Request){
+    leader, err := h.LeaderSrv.GetRandom(r.Context())
+	if err != nil {
+		sharedC.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(leader)
+}

--- a/pkg/features/app/leader/handler/handler.go
+++ b/pkg/features/app/leader/handler/handler.go
@@ -17,6 +17,7 @@ func NewLeaderHandler(server *http.ServeMux, leaderSrv port.LeaderSrv) *Handler 
 
 	server.HandleFunc("POST /leaders", h.Create)
 	server.HandleFunc("POST /leaders/{leaderId}/image/{type}", h.UploadAvatar)
+	server.HandleFunc("GET /leaders/random", h.GetRandom)
 	
 	return h
 }

--- a/pkg/features/app/leader/port/ports.go
+++ b/pkg/features/app/leader/port/ports.go
@@ -12,13 +12,16 @@ type LeaderRepo interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	UpdateAvatarPath(ctx context.Context, leaderID, imgPath string) error
 	UpdateBannerPath(ctx context.Context, leaderID, imgPath string) error
+	GetRandom(ctx context.Context) (*domain.Leader, error)
 }
 
 type LeaderSrv interface {
 	Create(ctx context.Context, leader *domain.Leader) error
 	UploadLeaderImage(ctx context.Context, leaderID, imgType, imgName string, file io.Reader, contentType string) error
+	GetRandom(ctx context.Context) (*domain.Leader, error)
 }
 
 type LeaderFileStg interface {
 	UploadImage(ctx context.Context, imgPath string, file io.Reader, contentType string) error
+	GetImage(ctx context.Context, imgPath string) (string, error) 
 }

--- a/pkg/features/app/leader/repository/mongo/get_random.go
+++ b/pkg/features/app/leader/repository/mongo/get_random.go
@@ -1,0 +1,42 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) GetRandom(ctx context.Context) (*domain.Leader, error) {
+	pipeline := mongo.Pipeline{
+		{{Key: "$sample", Value: bson.D{{Key: "size", Value: 1}}}},
+	}
+
+	cursor, err := r.Collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate random leader: %w", err)
+
+	}
+	defer cursor.Close(ctx)
+
+	var leaders []domain.Leader
+	if err := cursor.All(ctx, &leaders); err != nil {
+		return nil, fmt.Errorf("failed to decode leader result: %w", err)
+	}
+
+	if len(leaders) == 0 {
+		return nil, fmt.Errorf("%w: random leader not found", sharedD.ErrNotFound)
+	}
+
+	leader := leaders[0]
+
+	// Parse MongoDB ObjectID to string
+	if oid, ok := leader.ID.(bson.ObjectID); ok {
+		leader.ID = oid.Hex()
+	}
+
+	return &leader, nil
+}

--- a/pkg/features/app/leader/service/get_random.go
+++ b/pkg/features/app/leader/service/get_random.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+
+	"github.com/amorindev/go-tmpl/pkg/features/app/leader/domain"
+	sharedD "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) GetRandom(ctx context.Context) (*domain.Leader, error) {
+	leader, err := s.LeaderRepo.GetRandom(ctx)
+	if err != nil {
+		return nil, sharedD.ManageError(err, "error getting random leader")
+	}
+
+	if leader.BannerPath != nil {
+		url, err := s.LeaderFileStg.GetImage(ctx, *leader.BannerPath)
+		if err != nil {
+			return nil, sharedD.ManageError(err, "error getting leader banner")
+		}
+		leader.BannerUrl = &url
+	}
+
+	if leader.AvatarPath != nil {
+		url, err := s.LeaderFileStg.GetImage(ctx, *leader.AvatarPath)
+		if err != nil {
+			return nil, sharedD.ManageError(err, "error getting leader avatar")
+		}
+		leader.AvatarUrl = &url
+	}
+
+	return leader, err
+}


### PR DESCRIPTION
### Tasks
- Retrieve a random leader
- Handle not found case when no leaders exist
- Generate presigned URLs for avatar and banner images
- Expose HTTP endpoint
- Return JSON response with consistent error handling

### End to end
<img width="996" height="587" alt="image" src="https://github.com/user-attachments/assets/f0394874-1a54-4abb-842a-8f1d483ccc3c" />

<img width="1366" height="688" alt="image" src="https://github.com/user-attachments/assets/ec703f1f-ff83-40f8-8d15-f97a0d4c2ba7" />

<img width="1366" height="687" alt="image" src="https://github.com/user-attachments/assets/4c0886a1-47a0-4d13-890b-2495dc3925e8" />


Close #8 