### PR TITLE
Feat (app-leader): add slug field with validation and unique index

### DIFF
--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -94,6 +94,11 @@ func New() http.Handler {
 		log.Fatal(err)
 	}
 
+	err = leaderRepo.CreateIndexes()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Adapters
 	mailerAdt := resendAdapter.NewResendAdt(resendCli, appEnvs.EmailFrom)
 

--- a/pkg/features/app/leader/core/core.go
+++ b/pkg/features/app/leader/core/core.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"regexp"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 
 // CreateLeaderReq represents the request structure for Leader creation
 type CreateLeaderReq struct {
+	Slug      string  `json:"slug"`
 	FullName  string  `json:"full_name"`
 	Phrase    *string `json:"phrase"`
 	Nickname  *string `json:"nickname"`
@@ -29,10 +31,49 @@ type CreateLeaderReq struct {
 	Website   *string `json:"website"`
 }
 
+// slugRegex validates SEO-friendly slugs.
+// Accepted:
+//   - lowercase letters (a–z)
+//   - numbers (0–9)
+//   - single hyphens between words
+//
+// Examples (valid):
+//   rafael
+//   rafael-lopez
+//   rafael-lopez-aliaga
+//
+// Examples (invalid):
+//   Rafael-Lopez   // uppercase letters
+//   rafael_lopez   // underscores (_)
+//   rafael lopez   // spaces
+//   rafael--lopez  // double hyphens
+//   -rafael        // starts with hyphen
+//   rafael-        // ends with hyphen
+//   rafaél         // accented characters
+//   rafael!        // special characters
+//   @rafael        // '@' is not allowed
+var slugRegex = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+
 func (req *CreateLeaderReq) IsCreateLeaderValid() error {
 	// Validate email field is not empty
 	if strings.TrimSpace(req.FullName) == "" {
 		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "full_name is required")
+	}
+
+	if strings.TrimSpace(req.Slug) == "" {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "slug is required")
+	}
+
+	if len(req.Slug) > 80 {
+		return sharedD.NewAppError(domain.ErrCodeInvalidParams, "slug is too long")
+	}
+
+	if !slugRegex.MatchString(req.Slug) {
+		return sharedD.NewAppError(
+			domain.ErrCodeInvalidParams,
+			"slug format is invalid (use lowercase letters, numbers and hyphens)",
+		)
 	}
 
 	if strings.TrimSpace(req.Biography) == "" {

--- a/pkg/features/app/leader/domain/domain.go
+++ b/pkg/features/app/leader/domain/domain.go
@@ -8,6 +8,7 @@ import "time"
 // ImgPath is stored in the database and used by the backend to build the final public URL.
 type Leader struct {
 	ID         interface{} `json:"id" bson:"_id"`
+	Slug       string      `json:"slug" bson:"slug"`
 	FullName   string      `json:"full_name" bson:"full_name"`
 	NickName   *string     `json:"nickname" bson:"nickname"`
 	Phrase     *string     `json:"phrase" bson:"phrase"`

--- a/pkg/features/app/leader/handler/create.go
+++ b/pkg/features/app/leader/handler/create.go
@@ -31,6 +31,7 @@ func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	leader := &domain.Leader{
+		Slug:        req.Slug,
 		FullName:    req.FullName,
 		NickName:    req.Nickname,
 		Phrase:      req.Phrase,

--- a/pkg/features/app/leader/repository/mongo/create_index.go
+++ b/pkg/features/app/leader/repository/mongo/create_index.go
@@ -1,0 +1,22 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// CreateIndexes sets a unique index on the "slug" field.
+func (r *Repository) CreateIndexes() error {
+	_, err := r.Collection.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys:    bson.D{{Key: "slug", Value: 1}},
+		Options: options.Index().SetUnique(true).SetName("slug"),
+	})
+	if err != nil {
+		return fmt.Errorf("error creating slug index: %w", err)
+	}
+	return nil
+}

--- a/pkg/features/app/leader/repository/mongo/repository.go
+++ b/pkg/features/app/leader/repository/mongo/repository.go
@@ -5,7 +5,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
-// Make sure Repository implements ports.PlayerRepository
+// Make sure Repository implements ports.LeaderRepo
 // at compile time
 var _ port.LeaderRepo = &Repository{}
 


### PR DESCRIPTION
### Tasks
- Add slug field to Leader domain and create request
- Validate slug format using SEO-friendly regex
- Enforce slug length and required constraints
- Persist slug when creating leaders
- Create unique MongoDB index for slug
- Initialize slug index on API v1 startup