### PR TITLE
Feat (app-leader): add death date validation and make social links optional

### DIFF
--- a/pkg/features/app/leader/core/core.go
+++ b/pkg/features/app/leader/core/core.go
@@ -19,12 +19,13 @@ type CreateLeaderReq struct {
 	Biography string  `json:"biography"`
 
 	BirthDate   *time.Time `json:"birth_date"`
+	DeathDate   *time.Time `json:"death_date"`
 	Nationality string     `json:"nationality"`
 	Gender      string     `json:"gender"`
 	Ideology    *string    `json:"ideology"`
 
-	Facebook  string  `json:"facebook"`
-	Instagram string  `json:"instagram"`
+	Facebook  *string `json:"facebook"`
+	Instagram *string `json:"instagram"`
 	Twitter   *string `json:"twitter"`
 	YouTube   *string `json:"youtube"`
 	Linkedin  *string `json:"linkedin"`
@@ -38,22 +39,23 @@ type CreateLeaderReq struct {
 //   - single hyphens between words
 //
 // Examples (valid):
-//   rafael
-//   rafael-lopez
-//   rafael-lopez-aliaga
+//
+//	rafael
+//	rafael-lopez
+//	rafael-lopez-aliaga
 //
 // Examples (invalid):
-//   Rafael-Lopez   // uppercase letters
-//   rafael_lopez   // underscores (_)
-//   rafael lopez   // spaces
-//   rafael--lopez  // double hyphens
-//   -rafael        // starts with hyphen
-//   rafael-        // ends with hyphen
-//   rafaél         // accented characters
-//   rafael!        // special characters
-//   @rafael        // '@' is not allowed
+//
+//	Rafael-Lopez   // uppercase letters
+//	rafael_lopez   // underscores (_)
+//	rafael lopez   // spaces
+//	rafael--lopez  // double hyphens
+//	-rafael        // starts with hyphen
+//	rafael-        // ends with hyphen
+//	rafaél         // accented characters
+//	rafael!        // special characters
+//	@rafael        // '@' is not allowed
 var slugRegex = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
-
 
 func (req *CreateLeaderReq) IsCreateLeaderValid() error {
 	// Validate email field is not empty
@@ -106,10 +108,28 @@ func (req *CreateLeaderReq) IsCreateLeaderValid() error {
 		}
 	}
 
-	if err := validator.ValidateSocialURL(req.Facebook, "facebook"); err != nil {
+	if req.DeathDate != nil {
+		// Prevent future death dates
+		if req.DeathDate.After(time.Now()) {
+			return sharedD.NewAppError(
+				domain.ErrCodeInvalidParams,
+				"death_date cannot be in the future",
+			)
+		}
+
+		// Death date must be after birth date
+		if req.BirthDate != nil && req.DeathDate.Before(*req.BirthDate) {
+			return sharedD.NewAppError(
+				domain.ErrCodeInvalidParams,
+				"death_date cannot be before birth_date",
+			)
+		}
+	}
+
+	if err := validator.ValidateOptionalURL(req.Facebook, "facebook"); err != nil {
 		return sharedD.NewAppError(domain.ErrCodeInvalidParams, err.Error())
 	}
-	if err := validator.ValidateSocialURL(req.Instagram, "instagram"); err != nil {
+	if err := validator.ValidateOptionalURL(req.Instagram, "instagram"); err != nil {
 		return sharedD.NewAppError(domain.ErrCodeInvalidParams, err.Error())
 	}
 	if err := validator.ValidateOptionalURL(req.Twitter, "twitter"); err != nil {

--- a/pkg/features/app/leader/domain/domain.go
+++ b/pkg/features/app/leader/domain/domain.go
@@ -19,12 +19,13 @@ type Leader struct {
 	BannerPath *string     `json:"-" bson:"banner_path"`
 
 	BirthDate   *time.Time `json:"birth_date" bson:"birth_date"`
+	DeathDate   *time.Time `json:"death_date" bson:"death_date"`
 	Nationality string     `json:"nationality" bson:"nationality"`
 	Gender      string     `json:"gender,omitempty" bson:"gender"`
 	Ideology    *string    `json:"ideology,omitempty" bson:"ideology"`
 
-	Facebook  string  `json:"facebook" bson:"facebook"`
-	Instagram string  `json:"instagram" bson:"instagram"`
+	Facebook  *string `json:"facebook" bson:"facebook"`
+	Instagram *string `json:"instagram" bson:"instagram"`
 	Twitter   *string `json:"twitter" bson:"twitter"`
 	YouTube   *string `json:"youtube" bson:"youtube"`
 	Linkedin  *string `json:"linkedin" bson:"linkedin"`


### PR DESCRIPTION
### Tasks

- Add death_date field to Leader and CreateLeaderReq models
- Validate death_date is not in the future
- Ensure death_date is after birth_date when both are provided
- Make Facebook and Instagram fields optional (*string)
- Replace social URL validation with optional URL validation
- Improve slug regex documentation formatting


<img width="1007" height="644" alt="image" src="https://github.com/user-attachments/assets/98367373-1bc8-4fb6-92be-e3574342259e" />

<img width="998" height="588" alt="image" src="https://github.com/user-attachments/assets/2d807fa3-c2bf-4e32-adc0-d23abff1d669" />

### Success
<img width="1000" height="562" alt="image" src="https://github.com/user-attachments/assets/a9cc2a4b-e33d-4c38-9750-b5899690f19e" />
<img width="992" height="401" alt="image" src="https://github.com/user-attachments/assets/de92290b-931f-417b-b55d-dc584d9470d2" />

